### PR TITLE
osprey: Use persist.radio.aosp_usr_pref_sel

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -8,3 +8,6 @@ ro.qc.sdk.audio.fluencetype=fluence
 # Display
 debug.hwui.use_buffer_age=false
 ro.sf.lcd_density=320
+
+# Radio
+persist.radio.aosp_usr_pref_sel=true


### PR DESCRIPTION
*To fix default data after reboot